### PR TITLE
🐛 fix: Corrige conflitos no Prisma ao criar cliente direto

### DIFF
--- a/src/api/direto/direto.service.ts
+++ b/src/api/direto/direto.service.ts
@@ -62,8 +62,8 @@ export class DiretoService {
         };
         throw new HttpException(retorno, 400);
       }
-      // Remove `valor` do spread para evitar argumento desconhecido no Prisma e mapear para `valorcd`
-      const { valor, token, ...rest } = createClienteDto;
+      // Remove `valor`, `token` e `id` do spread para evitar conflitos no Prisma
+      const { valor, token, id, ...rest } = createClienteDto as any;
       const tokenDecode = (await this.processar({
         operation: 'parse',
         payload: { hash: token },


### PR DESCRIPTION
- Remove ,  e uid=1000(ti001) gid=1007(ti001) grupos=1007(ti001),3(sys),90(network),94(floppy),96(scanner),98(power),109(vboxsf),970(realtime),972(sambashare),985(video),991(lp),994(input),996(audio),998(wheel),1000(cdrom),1001(dip),1002(plugdev),1003(netdev),1004(lpadmin),1005(bluetooth),1006(scard) do spread para evitar argumentos desconhecidos e conflitos no Prisma ao criar cliente direto.