### PR TITLE
🐛 fix: Lança exceção NotFoundException se solicitação não encontrada

### DIFF
--- a/src/api/solicitacao/solicitacao.service.ts
+++ b/src/api/solicitacao/solicitacao.service.ts
@@ -1,4 +1,4 @@
-import { HttpException, Injectable, Logger } from '@nestjs/common';
+import { HttpException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { CreateSolicitacaoDto } from './dto/create-solicitacao.dto';
 import { UpdateSolicitacaoDto } from './dto/update-solicitacao.dto';
 import { ErrorEntity } from 'src/entities/error.entity';
@@ -507,6 +507,9 @@ export class SolicitacaoService {
           tags: true,
         },
       });
+      if (!req) {
+        throw new NotFoundException('Solicitação não encontrada ou você não tem permissão para acessá-la', '404');
+      }
 
       const ficha = req.id_fcw
         ? await this.GetFcweb(req.id_fcw)
@@ -550,7 +553,7 @@ export class SolicitacaoService {
       const retorno: ErrorEntity = {
         message: error.message,
       };
-      throw new HttpException(retorno, 400);
+      throw new HttpException(retorno, error.status);
     }
   }
   


### PR DESCRIPTION
- Garante que uma exceção NotFoundException seja lançada quando a solicitação não é encontrada ou o usuário não tem permissão para acessá-la.
- Corrige o status de erro retornado para o cliente.