### PR TITLE
🐛 fix: Usa variável de ambiente para token do Whatsapp

### DIFF
--- a/src/sms/sms.service.ts
+++ b/src/sms/sms.service.ts
@@ -16,7 +16,7 @@ export class SmsService {
       {
         method: 'POST',
         headers: {
-          'access-token': '60de0c8bb0012f1e6ac5546b',
+          'access-token': process.env.WHATSAPP_KEY || '',
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
@@ -40,7 +40,7 @@ export class SmsService {
       {
         method: 'POST',
         headers: {
-          'access-token': '60de0c8bb0012f1e6ac5546b',
+          'access-token': process.env.WHATSAPP_KEY || '',
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
@@ -87,7 +87,7 @@ export class SmsService {
         {
           method: 'POST',
           headers: {
-            'access-token': process.env.WHATSAPP_TOKEN || '',
+            'access-token': process.env.WHATSAPP_KEY || '',
             'Content-Type': 'application/json',
           },
           body: JSON.stringify(data),


### PR DESCRIPTION
- Corrige a utilização do token do Whatsapp para usar a variável de ambiente WHATSAPP_KEY, ao invés do valor fixo.