### PR TITLE
🐛 fix: Corrige refresh token e busca status envelope

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -379,7 +379,7 @@ model Intelesign {
 model AppToken {
   id           Int       @id @default(1)
   access_token String
-  expires_in   BigInt
+  expires_in   Int
   createdAt    DateTime  @default(now())
   updatedAt    DateTime? @updatedAt
 

--- a/src/api/intelesign/intelesign.controller.ts
+++ b/src/api/intelesign/intelesign.controller.ts
@@ -48,6 +48,11 @@ export class IntelesignController {
 
   @Post()
   @ApiConsumes('multipart/form-data')
+  @ApiOperation({
+    summary: 'Cria um novo envelope.',
+    description:
+      'Rota para criar um novo envelope, recebendo um arquivo e as informações do envelope via FormData.',
+  })
   @ApiBody({
     schema: {
       type: 'object',
@@ -141,8 +146,7 @@ export class IntelesignController {
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Busca o status de um envelope.',
-    description:
-      'Rota para buscar o status de um envelope.',
+    description: 'Rota para buscar o status de um envelope.',
   })
   @ApiOkResponse({
     description: 'Busca um registro de envelope.',


### PR DESCRIPTION
- Corrige a lógica de expiração do token para utilizar  corretamente.
- Adiciona logs para debug na busca de status do envelope.
- Ajusta a URL da busca de status do envelope para incluir o parâmetro .
- Trata erros na resposta da API ao buscar o status do envelope, exibindo a mensagem de erro.
- Corrige o tipo de dado do campo  no schema do prisma de  para