### PR TITLE
🐛 fix: Corrige busca e atualização de signatários

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -154,6 +154,7 @@
     "spreadsheetml",
     "susseso",
     "taglist",
+    "testsignatario",
     "tipocd",
     "totalhoras",
     "txid",


### PR DESCRIPTION
- Corrige a lógica de busca e atualização de signatários no serviço Intelesign.
- Garante que a busca por CPF e email seja feita dentro do contexto do envelope correto.
- Adiciona include para trazer os signatários na busca do envelope.