### PR TITLE
✨ feat: implementa campo fcweb_unico e nova permissão de agente de re…

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,6 +59,7 @@ model Solicitacao {
   gov               Boolean         @default(false)
   conf_devolucao    Boolean         @default(false)
   dt_conf_devolucao DateTime?
+  fcweb_unico       String?
   alerts            Alert[]
   Direto            Direto[]
   construtora       Construtora?    @relation("ConstrutoraSolicitacoes", fields: [construtoraId], references: [id])
@@ -202,12 +203,12 @@ model Empreendimento {
 model Alert {
   id             Int          @id @unique @default(autoincrement())
   solicitacao_id Int?
-  status         Boolean      @default(true) // Usaremos como "Ativa/Arquivada"
-  lido           Boolean      @default(false) // Novo campo: "Lida/Não lida"
+  status         Boolean      @default(true)
   createdAt      DateTime     @default(now())
   updatedAt      DateTime?    @updatedAt
   descricao      String
   corretor_id    Int?
+  lido           Boolean      @default(false)
   corretor       User?        @relation(fields: [corretor_id], references: [id], onUpdate: SetNull)
   solicitacao    Solicitacao? @relation(fields: [solicitacao_id], references: [id], onUpdate: SetNull)
 

--- a/src/api/solicitacao/entities/solicitacao.entity.ts
+++ b/src/api/solicitacao/entities/solicitacao.entity.ts
@@ -322,6 +322,11 @@ export class SolicitacaoEntity {
   @IsOptional()
   dt_conf_devolucao: Date | null;
 
+  @IsString()
+  @ApiResponseProperty({ type: String })
+  @IsOptional()
+  fcweb_unico: string;
+
   constructor(partial: Partial<SolicitacaoEntity>) {
     Object.assign(this, partial);
   }

--- a/src/api/solicitacao/solicitacao.service.ts
+++ b/src/api/solicitacao/solicitacao.service.ts
@@ -392,6 +392,7 @@ export class SolicitacaoService {
           },
         },
         id_fcw: true,
+        fcweb_unico: true,
         statusAtendimento: true,
         ativo: true,
         pause: true,
@@ -431,6 +432,7 @@ export class SolicitacaoService {
                       ...(ficha.andamento === 'APROVADO' && { gov: false }),
                       ...(ficha.andamento === 'EMITIDO' && { gov: false }),
                       andamento: ficha.andamento,
+                      fcweb_unico: ficha.unico,
                       type_validacao: ficha.validacao,
                       dt_agendamento: this.formatDateString(ficha.dt_agenda),
                       hr_agendamento: this.formatTimeString(ficha.hr_agenda),
@@ -447,6 +449,7 @@ export class SolicitacaoService {
                     ...(ficha.andamento === 'EMITIDO' && { gov: false }),
                     andamento: ficha.andamento,
                     type_validacao: ficha.validacao,
+                    fcweb_unico: ficha.unico,
                     dt_agendamento: this.formatDateString(ficha.dt_agenda),
                     hr_agendamento: this.formatTimeString(ficha.hr_agenda),
                     dt_aprovacao: this.formatDateString(ficha.dt_aprovacao),
@@ -576,7 +579,6 @@ export class SolicitacaoService {
           tags: true,
         },
       });
-      console.log('🚀 ~ SolicitacaoService ~ findOne ~ req:', req);
       if (!req) {
         throw new NotFoundException(
           'Solicitação não encontrada ou você não tem permissão para acessá-la',
@@ -600,6 +602,7 @@ export class SolicitacaoService {
             ...(ficha.andamento === 'APROVADO' && { gov: false }),
             ...(ficha.andamento === 'EMITIDO' && { gov: false }),
             andamento: ficha.andamento,
+            fcweb_unico: ficha.unico,
             type_validacao: ficha.validacao,
             dt_agendamento: this.formatDateString(ficha.dt_agenda),
             hr_agendamento: this.formatTimeString(ficha.hr_agenda),
@@ -609,6 +612,7 @@ export class SolicitacaoService {
         });
 
         req.andamento = ficha.andamento;
+        req.fcweb_unico = ficha.unico;
         if (!req.id_fcw) {
           req.id_fcw = ficha.id;
         }
@@ -1213,6 +1217,7 @@ export class SolicitacaoService {
     hr_aprovacao: string;
     validacao: string;
     nome: string;
+    unico: string;
   } | null> {
     try {
       const fcweb = await this.fcwebProvider.findByIdMin(id);
@@ -1241,6 +1246,7 @@ export class SolicitacaoService {
     hr_aprovacao: string;
     validacao: string;
     nome: string;
+    unico: string;
   } | null> {
     if (!cpf) {
       this.logger.warn('CPF não fornecido para busca no Fcweb');

--- a/src/api/user/dto/create-use-role.dto.ts
+++ b/src/api/user/dto/create-use-role.dto.ts
@@ -143,4 +143,14 @@ export class CreateUseRoleDto {
   @IsBoolean({ message: 'relatorio deve ser true ou false' })
   @IsOptional()
   relatorio?: boolean;
+
+  @ApiProperty({
+    type: Boolean,
+    required: false,
+    title: 'Agente de Registro',
+    description: 'Permite que o usuário atue como Agente de Registro',
+  })
+  @IsBoolean({ message: 'agente_registro deve ser true ou false' })
+  @IsOptional()
+  agente_registro?: boolean;
 }

--- a/src/api/user/dto/create-user.dto.ts
+++ b/src/api/user/dto/create-user.dto.ts
@@ -107,6 +107,7 @@ export class CreateUserDto {
       solicitacao: false,
       lista_finace: false,
       empreendimento: true,
+      agente_registro: false,
     },
   })
   @IsOptional()

--- a/src/api/user/dto/update-user.dto.ts
+++ b/src/api/user/dto/update-user.dto.ts
@@ -128,6 +128,7 @@ export class UpdateUserDto {
       solicitacao: false,
       lista_finace: false,
       empreendimento: true,
+      agente_registro: false,
     },
   })
   @IsOptional()

--- a/src/sequelize/providers/fcweb.ts
+++ b/src/sequelize/providers/fcweb.ts
@@ -21,6 +21,7 @@ export class FcwebProvider {
     hr_aprovacao: string;
     validacao: string;
     nome: string;
+    unico: string;
   }> {
     const req = await Fcweb.findByPk(id, {
       attributes: [
@@ -32,6 +33,7 @@ export class FcwebProvider {
         'hr_aprovacao',
         'validacao',
         'nome',
+        'unico',
       ],
       raw: true,
     });
@@ -54,6 +56,7 @@ export class FcwebProvider {
     hr_aprovacao: string;
     validacao: string;
     nome: string;
+    unico: string;
   }> {
     const req = await Fcweb.findOne({
       attributes: [
@@ -65,6 +68,7 @@ export class FcwebProvider {
         'hr_aprovacao',
         'validacao',
         'nome',
+        'unico',
       ],
       where: {
         cpf: cpf,
@@ -99,7 +103,11 @@ export class FcwebProvider {
    * @returns {id: number; andamento: string; dt_agenda: Date; hr_agenda: string; dt_aprovacao: Date; hr_aprovacao: string; dt_revogacao: Date; modelo: string; valor_cert: number; formapgto: string; validacao: string; tipocd: string }[]}
    *
    */
-  async findAllCpfMin(cpf: string, Inicio: string, Fim: string): Promise<
+  async findAllCpfMin(
+    cpf: string,
+    Inicio: string,
+    Fim: string,
+  ): Promise<
     {
       id: number;
       andamento: string;
@@ -161,7 +169,6 @@ export class FcwebProvider {
 
     return data;
   }
-
 
   async findIdfMinRelat(id: number): Promise<
     {


### PR DESCRIPTION
…gistro

- Adiciona o campo fcweb_unico ao modelo Solicitacao no schema do Prisma e na respectiva entidade.
- Atualiza o SolicitacaoService para realizar o mapeamento do campo unico retornado pelo provedor Fcweb.
- Introduz a propriedade agente_registro nos DTOs de criação e atualização de usuários e permissões.
- Modifica o FcwebProvider para incluir a coluna unico nas consultas de busca por ID e CPF no Sequelize.
- Remove logs de depuração (console.log) no serviço de solicitações.
- Ajusta a ordenação de campos e remove comentários redundantes no modelo Alert do schema Prisma.