### PR TITLE
✨ feat: implementa módulo de analytics para dashboard e rankings

### DIFF
--- a/src/api/analytics/analytics.controller.spec.ts
+++ b/src/api/analytics/analytics.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AnalyticsController } from './analytics.controller';
+import { AnalyticsService } from './analytics.service';
+
+describe('AnalyticsController', () => {
+  let controller: AnalyticsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AnalyticsController],
+      providers: [AnalyticsService],
+    }).compile();
+
+    controller = module.get<AnalyticsController>(AnalyticsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/api/analytics/analytics.controller.ts
+++ b/src/api/analytics/analytics.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { AnalyticsService } from './analytics.service';
+import { GetAnalyticsQueryDto } from './dto/get-analytics-query.dto';
+
+@Controller('analytics')
+export class AnalyticsController {
+  constructor(private readonly analyticsService: AnalyticsService) {}
+
+  @Get('overview')
+  async getOverview(@Query() query: GetAnalyticsQueryDto) {
+    return this.analyticsService.getDashboardData(query);
+  }
+
+  @Get('ranking')
+  async getRanking(@Query() query: GetAnalyticsQueryDto) {
+    return this.analyticsService.getRankingData(query);
+  }
+}

--- a/src/api/analytics/analytics.module.ts
+++ b/src/api/analytics/analytics.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AnalyticsService } from './analytics.service';
+import { AnalyticsController } from './analytics.controller';
+
+@Module({
+  controllers: [AnalyticsController],
+  providers: [AnalyticsService],
+})
+export class AnalyticsModule {}

--- a/src/api/analytics/analytics.service.spec.ts
+++ b/src/api/analytics/analytics.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AnalyticsService } from './analytics.service';
+
+describe('AnalyticsService', () => {
+  let service: AnalyticsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AnalyticsService],
+    }).compile();
+
+    service = module.get<AnalyticsService>(AnalyticsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/api/analytics/analytics.service.ts
+++ b/src/api/analytics/analytics.service.ts
@@ -1,0 +1,319 @@
+import { Injectable } from '@nestjs/common';
+import { GetAnalyticsQueryDto } from './dto/get-analytics-query.dto';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { FcwebReagendamentoProvider } from 'src/sequelize/providers/fcweb-reagendamento.provider';
+
+@Injectable()
+export class AnalyticsService {
+  constructor(
+    private prisma: PrismaService,
+    private reagendamentoProvider: FcwebReagendamentoProvider,
+  ) {}
+
+  async getDashboardData(query: GetAnalyticsQueryDto) {
+    const { startDate, endDate, construtoraId, financeiroId, corretorId } =
+      query;
+
+    const where: any = {
+      createdAt: {
+        gte: startDate ? new Date(startDate) : undefined,
+        lte: endDate ? new Date(endDate) : undefined,
+      },
+      ...(construtoraId && { construtoraId }),
+      ...(financeiroId && { financeiroId }),
+      ...(corretorId && { corretorId }),
+    };
+
+    const solicitacoes = await this.prisma.solicitacao.findMany({
+      where,
+      select: {
+        id: true,
+        id_fcw: true,
+        createdAt: true,
+        dt_agendamento: true,
+        dt_aprovacao: true,
+        andamento: true,
+        status_aprovacao: true,
+        dt_revogacao: true,
+        pause: true,
+        gov: true,
+        distrato: true,
+        ativo: true,
+        type_validacao: true,
+      },
+    });
+
+    const idsFcw = solicitacoes
+      .map((s) => s.id_fcw)
+      .filter((id): id is number => id !== null);
+
+    const totalReagendamentos =
+      await this.reagendamentoProvider.countByFcwebIds(idsFcw);
+
+    const metrics = this.processMetrics(solicitacoes);
+
+    return {
+      ...metrics,
+      totals: {
+        ...metrics.totals,
+        reagendamentos: totalReagendamentos,
+      },
+    };
+  }
+
+  private processMetrics(data: any[]) {
+    const totals = {
+      abertas: 0,
+      emitidos: 0,
+      revogado: 0,
+      pausado: 0,
+      enviado_gov: 0,
+      distrato: 0,
+      deletado: 0,
+      video: 0,
+      presencial: 0,
+    };
+
+    const THREE_HOURS_MS = 3 * 60 * 60 * 1000;
+
+    let sumMsAberturaAgendamento = 0;
+    let countAgendamento = 0;
+    let sumMsAgendamentoAprovacao = 0;
+    let countAgendamentoAprovacao = 0;
+    let sumMsAberturaAprovacao = 0;
+    let countAprovacao = 0;
+
+    const getFullTimestamp = (datePart: Date | null, timePart: Date | null) => {
+      if (!datePart) return null;
+      const combined = new Date(datePart);
+      if (timePart) {
+        const time = new Date(timePart);
+        combined.setUTCHours(
+          time.getUTCHours(),
+          time.getUTCMinutes(),
+          time.getUTCSeconds(),
+          0,
+        );
+      }
+      return combined.getTime() - THREE_HOURS_MS;
+    };
+
+    data.forEach((item) => {
+      if (item.ativo === false) {
+        totals.deletado++;
+        return;
+      }
+
+      // --- CONTAGEM DE TOTAIS ---
+      if (item.distrato) totals.distrato++;
+      if (item.gov) totals.enviado_gov++;
+      if (item.pause) totals.pausado++;
+      const andamento = item.andamento?.toUpperCase();
+      if (
+        andamento === 'EMITIDO' ||
+        andamento === 'APROVADO' ||
+        item.dt_aprovacao
+      )
+        totals.emitidos++;
+      if (!andamento && !item.pause && !item.distrato && !item.gov)
+        totals.abertas++;
+
+      const tipo = item.type_validacao?.toUpperCase() || '';
+      if (tipo.includes('VIDEO')) totals.video++;
+      else if (tipo.includes('INTERNA') || tipo.includes('EXTERNA'))
+        totals.presencial++;
+
+      // --- CÁLCULOS COM CORREÇÃO DE OFFSET (-3h) ---
+
+      // T1: ABERTURA
+      const tAbertura = new Date(item.createdAt).getTime() - THREE_HOURS_MS;
+
+      // T2: AGENDAMENTO
+      const tAgendamento = getFullTimestamp(
+        item.dt_agendamento,
+        item.hr_agendamento,
+      );
+
+      // T3: APROVAÇÃO
+      const tAprovacao = getFullTimestamp(item.dt_aprovacao, item.hr_aprovacao);
+
+      if (tAgendamento) {
+        // CONTA 1: Abertura -> Agendamento
+        const businessDiff1 = this.getBusinessTimeDiff(tAbertura, tAgendamento);
+        sumMsAberturaAgendamento += businessDiff1;
+        countAgendamento++;
+
+        if (tAprovacao) {
+          // CONTA 2: Agendamento -> Aprovação
+          const businessDiff2 = this.getBusinessTimeDiff(
+            tAgendamento,
+            tAprovacao,
+          );
+          sumMsAgendamentoAprovacao += businessDiff2;
+          countAgendamentoAprovacao++;
+
+          // CONTA 3: Abertura -> Aprovação
+          const businessDiff3 = this.getBusinessTimeDiff(tAbertura, tAprovacao);
+          sumMsAberturaAprovacao += businessDiff3;
+          countAprovacao++;
+        }
+      }
+    });
+
+    const formatToClock = (totalMs: number, count: number) => {
+      if (count === 0) return '00h 00min';
+      const averageMs = totalMs / count;
+      const totalMinutes = Math.floor(averageMs / (1000 * 60));
+      const hours = Math.floor(totalMinutes / 60);
+      const mins = totalMinutes % 60;
+      return `${hours.toString().padStart(2, '0')}h ${mins.toString().padStart(2, '0')}min`;
+    };
+
+    return {
+      totals,
+      medias_nato: {
+        abertura_para_agendamento: formatToClock(
+          sumMsAberturaAgendamento,
+          countAgendamento,
+        ),
+        agendamento_para_aprovacao: formatToClock(
+          sumMsAgendamentoAprovacao,
+          countAgendamentoAprovacao,
+        ),
+        abertura_para_aprovacao: formatToClock(
+          sumMsAberturaAprovacao,
+          countAprovacao,
+        ),
+      },
+    };
+  }
+
+  private getBusinessTimeDiff(startDateMs: number, endDateMs: number): number {
+    if (endDateMs <= startDateMs) return 0;
+
+    let totalMs = 0;
+    let currentPtr = new Date(startDateMs);
+    const end = new Date(endDateMs);
+
+    if (currentPtr.toDateString() === end.toDateString()) {
+      const day = currentPtr.getDay();
+      if (day === 0 || day === 6) return 0;
+      return endDateMs - startDateMs;
+    }
+
+    let tempStart = startDateMs;
+
+    while (tempStart < endDateMs) {
+      const currentDate = new Date(tempStart);
+      const dayOfWeek = currentDate.getDay();
+
+      const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
+
+      if (!isWeekend) {
+        const endOfDay = new Date(currentDate).setUTCHours(23, 59, 59, 999);
+        const nextStep = Math.min(endDateMs, endOfDay);
+
+        totalMs += nextStep - tempStart;
+      }
+
+      const nextDay = new Date(currentDate);
+      nextDay.setUTCDate(nextDay.getUTCDate() + 1);
+      nextDay.setUTCHours(0, 0, 0, 0);
+      tempStart = nextDay.getTime();
+    }
+
+    return totalMs;
+  }
+
+  async getRankingData(query: GetAnalyticsQueryDto) {
+    const { startDate, endDate, construtoraId, financeiroId } = query;
+
+    // Filtro base de data e ativos
+    const where: any = {
+      ativo: true,
+      createdAt: {
+        gte: startDate ? new Date(startDate) : undefined,
+        lte: endDate ? new Date(endDate) : undefined,
+      },
+      ...(construtoraId && { construtoraId }),
+      ...(financeiroId && { financeiroId }),
+      OR: [
+        { andamento: 'EMITIDO' },
+        { andamento: 'APROVADO' },
+        { dt_aprovacao: { not: null } },
+      ],
+    };
+
+    const [construtoras, financeiras, corretores] = await Promise.all([
+      this.prisma.solicitacao.groupBy({
+        by: ['construtoraId'],
+        where,
+        _count: { id: true },
+        orderBy: { _count: { id: 'desc' } },
+        take: 10,
+      }),
+      this.prisma.solicitacao.groupBy({
+        by: ['financeiroId'],
+        where,
+        _count: { id: true },
+        orderBy: { _count: { id: 'desc' } },
+        take: 10,
+      }),
+      this.prisma.solicitacao.groupBy({
+        by: ['corretorId'],
+        where,
+        _count: { id: true },
+        orderBy: { _count: { id: 'desc' } },
+        take: 10,
+      }),
+    ]);
+
+    return this.mapRankingNames(construtoras, financeiras, corretores);
+  }
+
+  private async mapRankingNames(
+    construtoras: any[],
+    financeiras: any[],
+    corretores: any[],
+  ) {
+    const cIds = construtoras.map((c) => c.construtoraId).filter(Boolean);
+    const fIds = financeiras.map((f) => f.financeiroId).filter(Boolean);
+    const uIds = corretores.map((u) => u.corretorId).filter(Boolean);
+
+    const cNames = await this.prisma.construtora.findMany({
+      where: { id: { in: cIds } },
+      select: { id: true, fantasia: true, razaosocial: true },
+    });
+
+    const fNames = await this.prisma.financeiro.findMany({
+      where: { id: { in: fIds } },
+      select: { id: true, fantasia: true, razaosocial: true },
+    });
+
+    const uNames = await this.prisma.user.findMany({
+      where: { id: { in: uIds } },
+      select: { id: true, nome: true },
+    });
+
+    return {
+      construtoras: construtoras.map((c) => ({
+        name:
+          cNames.find((n) => n.id === c.construtoraId)?.fantasia ||
+          cNames.find((n) => n.id === c.construtoraId)?.razaosocial ||
+          'Não Identificada',
+        total: c._count.id,
+      })),
+      financeiras: financeiras.map((f) => ({
+        name:
+          fNames.find((n) => n.id === f.financeiroId)?.fantasia ||
+          fNames.find((n) => n.id === f.financeiroId)?.razaosocial ||
+          'Não Identificada',
+        total: f._count.id,
+      })),
+      corretores: corretores.map((u) => ({
+        name: uNames.find((n) => n.id === u.corretorId)?.nome || 'Sistema',
+        total: u._count.id,
+      })),
+    };
+  }
+}

--- a/src/api/analytics/dto/create-analytics.dto.ts
+++ b/src/api/analytics/dto/create-analytics.dto.ts
@@ -1,0 +1,1 @@
+export class CreateAnalyticsDto {}

--- a/src/api/analytics/dto/get-analytics-query.dto.ts
+++ b/src/api/analytics/dto/get-analytics-query.dto.ts
@@ -1,0 +1,27 @@
+import { IsOptional, IsString, IsDateString, IsInt } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class GetAnalyticsQueryDto {
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  construtoraId?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  financeiroId?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  corretorId?: number;
+}

--- a/src/api/analytics/dto/update-analytics.dto.ts
+++ b/src/api/analytics/dto/update-analytics.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateAnalyticsDto } from './create-analytics.dto';
+
+export class UpdateAnalyticsDto extends PartialType(CreateAnalyticsDto) {}

--- a/src/api/analytics/entities/analytics.entity.ts
+++ b/src/api/analytics/entities/analytics.entity.ts
@@ -1,0 +1,1 @@
+export class Analytics {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -38,6 +38,7 @@ import { ArParceiraModule } from './ar-parceira/ar-parceira.module';
 import { SolutiModule } from './soluti/soluti.module';
 import { VoucherModule } from './api/voucher/voucher.module';
 import { ScheduleModule } from '@nestjs/schedule';
+import { AnalyticsModule } from './api/analytics/analytics.module';
 
 @Module({
   imports: [
@@ -80,6 +81,7 @@ import { ScheduleModule } from '@nestjs/schedule';
     ArParceiraModule,
     SolutiModule,
     VoucherModule,
+    AnalyticsModule,
   ],
 })
 export class AppModule {}

--- a/src/sequelize/models/fcweb-reagendamento.model.ts
+++ b/src/sequelize/models/fcweb-reagendamento.model.ts
@@ -1,0 +1,28 @@
+import { Table, Column, Model, DataType } from 'sequelize-typescript';
+
+@Table({
+  tableName: 'fcweb_reagendamentos', // Nome exato da tabela no banco
+  timestamps: false,
+})
+export class FcwebReagendamento extends Model {
+  @Column({ type: DataType.INTEGER, primaryKey: true, autoIncrement: true })
+  id: number;
+
+  @Column({ type: DataType.INTEGER, allowNull: false })
+  id_fcweb: number;
+
+  @Column({ type: DataType.DATEONLY, allowNull: false })
+  data_reagenda: Date;
+
+  @Column({ type: DataType.TIME, allowNull: false })
+  hora_reagenda: string;
+
+  @Column({ type: DataType.TEXT })
+  motivo: string;
+
+  @Column({ type: DataType.STRING(100) })
+  criado_por: string;
+
+  @Column({ type: DataType.DATE, defaultValue: DataType.NOW })
+  criado_em: Date;
+}

--- a/src/sequelize/providers/fcweb-reagendamento.provider.ts
+++ b/src/sequelize/providers/fcweb-reagendamento.provider.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { FcwebReagendamento } from '../models/fcweb-reagendamento.model';
+import { Op } from 'sequelize';
+
+@Injectable()
+export class FcwebReagendamentoProvider {
+  // Busca quantos reagendamentos existem para uma lista de IDs de solicitações NATO
+  async countByFcwebIds(ids: number[]): Promise<number> {
+    if (!ids.length) return 0;
+
+    return FcwebReagendamento.count({
+      where: {
+        id_fcweb: {
+          [Op.in]: ids,
+        },
+      },
+    });
+  }
+
+  // Busca a lista detalhada caso queira mostrar no dashboard quem reagendou
+  async findByFcwebIds(ids: number[]): Promise<FcwebReagendamento[]> {
+    if (!ids.length) return [];
+
+    return FcwebReagendamento.findAll({
+      where: {
+        id_fcweb: {
+          [Op.in]: ids,
+        },
+      },
+      raw: true,
+    });
+  }
+}

--- a/src/sequelize/sequelize.module.ts
+++ b/src/sequelize/sequelize.module.ts
@@ -1,10 +1,11 @@
 import { Global, Module } from '@nestjs/common';
 import { Sequelize } from './sequelize';
 import { FcwebProvider } from './providers/fcweb';
+import { FcwebReagendamentoProvider } from './providers/fcweb-reagendamento.provider';
 
 @Global()
 @Module({
-  providers: [Sequelize, FcwebProvider],
-  exports: [Sequelize, FcwebProvider],
+  providers: [Sequelize, FcwebProvider, FcwebReagendamentoProvider],
+  exports: [Sequelize, FcwebProvider, FcwebReagendamentoProvider],
 })
 export class SequelizeModule {}

--- a/src/sequelize/sequelize.ts
+++ b/src/sequelize/sequelize.ts
@@ -1,6 +1,7 @@
 import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { Sequelize as SequelizeInstance } from 'sequelize-typescript';
 import { Fcweb } from './models/fcweb.model';
+import { FcwebReagendamento } from './models/fcweb-reagendamento.model';
 
 @Injectable()
 export class Sequelize implements OnModuleInit, OnModuleDestroy {
@@ -59,7 +60,7 @@ export class Sequelize implements OnModuleInit, OnModuleDestroy {
         });
 
       // Adiciona os modelos
-      this.sequelizeInstance.addModels([Fcweb]);
+      this.sequelizeInstance.addModels([Fcweb, FcwebReagendamento]);
     } catch (error) {
       console.error('❌ Erro ao inicializar o Sequelize:', error);
       this.isConnected = false;


### PR DESCRIPTION
- Cria AnalyticsController com endpoints para obtenção de visão geral e dados de ranking.
- Implementa AnalyticsService para consolidação de métricas de solicitações via Prisma.
- Adiciona lógica de processamento de indicadores (SLA) com cálculo de tempo útil (business time) e compensação de timezone.
- Integra contagem de reagendamentos através do FcwebReagendamentoProvider.
- Define estrutura de filtros por período, construtora, financeiro e corretor via DTO.
- Adiciona testes unitários para validação das instâncias de controller e service.
- Configura AnalyticsModule para injeção de dependências do módulo.